### PR TITLE
Fix ModuleNotFoundError

### DIFF
--- a/SIMLR/__init__.py
+++ b/SIMLR/__init__.py
@@ -1,1 +1,1 @@
-from core import SIMLR_LARGE
+from .core import SIMLR_LARGE


### PR DESCRIPTION
`core.py` in SIMLR is not imported correctly.
run `python test_largescale.py` will raise
```
ModuleNotFoundError: No module named 'core'
```