### PR TITLE
Compatible with Python 3

### DIFF
--- a/SIMLR/__init__.py
+++ b/SIMLR/__init__.py
@@ -1,1 +1,1 @@
-from core import SIMLR_LARGE
+from .core import SIMLR_LARGE

--- a/SIMLR/core.py
+++ b/SIMLR/core.py
@@ -50,6 +50,10 @@ import time
 from sklearn.decomposition import TruncatedSVD
 from sklearn.cluster import MiniBatchKMeans, KMeans
 
+if sys.version_info.major == 3:
+    xrange = range  # xrange() was renamed to range() in Python 3.
+
+
 class SIMLR_LARGE(object):
     """A class for large-scale SIMLR.
 


### PR DESCRIPTION
The code of current version is Python 2 only because of `xrange()` function.
[`xrange()` was renamed to `range()` in Python 3.](https://docs.python.org/3/library/2to3.html#2to3fixer-xrange)

